### PR TITLE
Create client id with correct serial number

### DIFF
--- a/src/Mews.Fiscalization.Germany.Tests/TransactionTests.cs
+++ b/src/Mews.Fiscalization.Germany.Tests/TransactionTests.cs
@@ -10,10 +10,10 @@ namespace Mews.Fiscalization.German.Tests
     [TestFixture]
     public class Tests
     {
-        private static readonly Guid ClientId = new Guid("INSERT_CLIENT_ID");
-        private static readonly Guid TssId = new Guid("INSERT_TSS_ID");
-        private static readonly ApiKey ApiKey = new ApiKey("INSERT_API_KEY");
-        private static readonly ApiSecret ApiSecret = new ApiSecret("INSERT_API_Secret");
+        private static readonly Guid ClientId = new Guid("f84da730-8074-4d40-8e7b-65998a7cec25");
+        private static readonly Guid TssId = new Guid("f84da730-8074-4d40-8e7b-65998a7cec25");
+        private static readonly ApiKey ApiKey = new ApiKey("test_dgyieu2fhj1jfj5em2pak6dli_test");
+        private static readonly ApiSecret ApiSecret = new ApiSecret("k3t6OZFfBtXaIfZsNPTWFn7KAFZQ3YAIjmLKZePTw16");
 
         [Test]
         public async Task StatusCheckSucceeds()
@@ -23,6 +23,14 @@ namespace Mews.Fiscalization.German.Tests
             var status = await client.GetClientAsync(accessToken, ClientId, TssId);
 
             Assert.IsTrue(status.IsSuccess);
+        }
+
+        [Test]
+        public async Task CreateClient()
+        {
+            var client = GetClient();
+            var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
+            var createdClient = await client.CreateClientAsync(accessToken, TssId);
         }
 
         [Test]

--- a/src/Mews.Fiscalization.Germany.Tests/TransactionTests.cs
+++ b/src/Mews.Fiscalization.Germany.Tests/TransactionTests.cs
@@ -10,10 +10,10 @@ namespace Mews.Fiscalization.German.Tests
     [TestFixture]
     public class Tests
     {
-        private static readonly Guid ClientId = new Guid("f84da730-8074-4d40-8e7b-65998a7cec25");
-        private static readonly Guid TssId = new Guid("f84da730-8074-4d40-8e7b-65998a7cec25");
-        private static readonly ApiKey ApiKey = new ApiKey("test_dgyieu2fhj1jfj5em2pak6dli_test");
-        private static readonly ApiSecret ApiSecret = new ApiSecret("k3t6OZFfBtXaIfZsNPTWFn7KAFZQ3YAIjmLKZePTw16");
+        private static readonly Guid ClientId = new Guid("INSERT_CLIENT_ID");
+        private static readonly Guid TssId = new Guid("INSERT_TSS_ID");
+        private static readonly ApiKey ApiKey = new ApiKey("INSERT_API_KEY");
+        private static readonly ApiSecret ApiSecret = new ApiSecret("INSERT_API_Secret");
 
         [Test]
         public async Task StatusCheckSucceeds()
@@ -26,11 +26,14 @@ namespace Mews.Fiscalization.German.Tests
         }
 
         [Test]
-        public async Task CreateClient()
+        public async Task CreateClientSucceeds()
         {
             var client = GetClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var createdClient = await client.CreateClientAsync(accessToken, TssId);
+
+            Assert.IsTrue(createdClient.IsSuccess);
+            Assert.IsNotNull(createdClient.SuccessResult.Id);
         }
 
         [Test]

--- a/src/Mews.Fiscalization.Germany/Dto/TssRequest.cs
+++ b/src/Mews.Fiscalization.Germany/Dto/TssRequest.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Mews.Fiscalization.Germany.Dto
+{
+    public sealed class TssRequest
+    {
+        [JsonProperty("tss_id")]
+        public Guid TssId { get; set; }
+    }
+}

--- a/src/Mews.Fiscalization.Germany/Dto/TssResponse.cs
+++ b/src/Mews.Fiscalization.Germany/Dto/TssResponse.cs
@@ -1,0 +1,54 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Mews.Fiscalization.Germany.Dto
+{
+    public enum TssState
+    {
+        UNINITIALIZED,
+        INITIALIZED,
+        DISABLED
+    }
+
+    public sealed class TssResponse
+    {
+        [JsonProperty("_id")]
+        public Guid Id { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("state")]
+        public TssState State { get; set; }
+
+        [JsonProperty("time_creation")]
+        public long TimeCreation { get; set; }
+
+        [JsonProperty("time_init")]
+        public long TimeInit { get; set; }
+
+        [JsonProperty("time_disable")]
+        public long TimeDisable { get; set; }
+
+        [JsonProperty("certificate")]
+        public string Certificate { get; set; }
+
+        [JsonProperty("certificate_serial")]
+        public string CertificateSerial { get; set; }
+
+        [JsonProperty("public_key")]
+        public string PublicKey { get; set; }
+
+        [JsonProperty("signature_counter")]
+        public int SignatureCounter { get; set; }
+
+        [JsonProperty("signature_algorithm")]
+        public string SignatureAlgorithm { get; set; }
+
+        [JsonProperty("signature_timestamp_format")]
+        public string SignatureTimestampFormat { get; set; }
+
+        [JsonProperty("transaction_counter")]
+        public long TransactionCounter { get; set; }
+    }
+}

--- a/src/Mews.Fiscalization.Germany/Model/Tss.cs
+++ b/src/Mews.Fiscalization.Germany/Model/Tss.cs
@@ -1,0 +1,66 @@
+﻿using System;
+
+namespace Mews.Fiscalization.Germany.Model
+{
+    public enum TssState
+    {
+        Uninitialized,
+        Initialized,
+        Disabled
+    }
+
+    public sealed class Tss
+    {
+        public Tss(
+            Guid id,
+            string description,
+            TssState state,
+            DateTime createdUtc,
+            DateTime initializedUtc,
+            DateTime disabledUtc,
+            string certificate,
+            string certificateSerial,
+            string publicKey,
+            int signatureCounter,
+            string signatureAlgorithm,
+            long transactionCounter)
+        {
+            Id = id;
+            Description = description;
+            State = state;
+            CreatedUtc = createdUtc;
+            InitializedUtc = initializedUtc;
+            DisabledUtc = disabledUtc;
+            Certificate = certificate;
+            CertificateSerial = certificateSerial;
+            PublicKey = publicKey;
+            SignatureCounter = signatureCounter;
+            SignatureAlgorithm = signatureAlgorithm;
+            TransactionCounter = transactionCounter;
+        }
+
+        public Guid Id { get; }
+
+        public string Description { get; }
+
+        public TssState State { get; }
+
+        public DateTime CreatedUtc { get; }
+
+        public DateTime InitializedUtc { get; }
+
+        public DateTime DisabledUtc { get; }
+
+        public string Certificate { get; }
+
+        public string CertificateSerial { get; }
+
+        public string PublicKey { get; }
+
+        public int SignatureCounter { get; }
+
+        public string SignatureAlgorithm { get; }
+
+        public long TransactionCounter { get; }
+    }
+}

--- a/src/Mews.Fiscalization.Germany/ModelMapper.cs
+++ b/src/Mews.Fiscalization.Germany/ModelMapper.cs
@@ -1,5 +1,6 @@
 ﻿using Mews.Fiscalization.Germany.Model;
 using Mews.Fiscalization.Germany.Utils;
+using System;
 
 namespace Mews.Fiscalization.Germany
 {
@@ -40,6 +41,39 @@ namespace Mews.Fiscalization.Germany
                 tssId: client.TssId,
                 id: client.Id
             ));
+        }
+
+        internal static ResponseResult<Model.Tss> MapTss(Dto.TssResponse tss)
+        {
+            return new ResponseResult<Model.Tss>(successResult: new Model.Tss(
+                id: tss.Id,
+                description: tss.Description,
+                state: MapTssState(tss.State),
+                createdUtc: tss.TimeCreation.FromUnixTime(),
+                initializedUtc: tss.TimeInit.FromUnixTime(),
+                disabledUtc: tss.TimeDisable.FromUnixTime(),
+                certificate: tss.Certificate,
+                certificateSerial: tss.CertificateSerial,
+                publicKey: tss.PublicKey,
+                signatureCounter: tss.SignatureCounter,
+                signatureAlgorithm: tss.SignatureAlgorithm,
+                transactionCounter: tss.TransactionCounter
+            ));
+        }
+
+        private static Model.TssState MapTssState(Dto.TssState state)
+        {
+            switch (state)
+            {
+                case Dto.TssState.DISABLED:
+                    return Model.TssState.Disabled;
+                case Dto.TssState.INITIALIZED:
+                    return Model.TssState.Initialized;
+                case Dto.TssState.UNINITIALIZED:
+                    return Model.TssState.Uninitialized;
+                default:
+                    throw new NotImplementedException($"Tss state: {state} is not implemented.");
+            };
         }
     }
 }

--- a/src/Mews.Fiscalization.Germany/RequestCreator.cs
+++ b/src/Mews.Fiscalization.Germany/RequestCreator.cs
@@ -24,6 +24,14 @@ namespace Mews.Fiscalization.Germany
             };
         }
 
+        internal static Dto.TssRequest CreateTss(Guid tssId)
+        {
+            return new Dto.TssRequest
+            {
+                TssId = tssId
+            };
+        }
+
         internal static Dto.FinishTransactionRequest FinishTransaction(Guid clientId, Bill bill)
         {
             var groupedPayments = bill.Payments.GroupBy(p => new { p.CurrencyCode, p.Type }).Select(g => new Payment(g.Sum(p => p.Amount), g.Key.Type, g.Key.CurrencyCode));


### PR DESCRIPTION
When creating a client, we should provide a valid Serial Number based on the following documentation: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR03153/TR-03153.pdf?__blob=publicationFile


Translation:
7.5 Requirements for assigning the serial number 
The serial number of an electronic recording system MUST be clearly assigned by the manufacturer. Together with the information about the manufacturer, this will uniquely represent the recording system. The Technical Security Device serial number MUST be the hash value of the key contained in the certificate, which is necessary for the verification of the test values in transaction log messages. The hash value MUST be encoded as an octet string. The hash function to be used is specified by [BSI TR-03116]. The serial number of the Technical Security Device MUST be transmitted to the responsible tax office in the context of the notification of the type of Technical Security Device according to §146a (4) [AO]. 
